### PR TITLE
Add different player trail effects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2721,6 +2721,8 @@ if(CLIENT)
     components/bestclient/orbit_aura.h
     components/bestclient/r_jelly.cpp
     components/bestclient/r_jelly.h
+    components/bestclient/r_trail.cpp
+    components/bestclient/r_trail.h
     components/bestclient/voice/protocol.h
     components/bestclient/voice/voice.cpp
     components/bestclient/voice/voice.h

--- a/src/engine/shared/config_variables_bestclient.h
+++ b/src/engine/shared/config_variables_bestclient.h
@@ -184,6 +184,11 @@ MACRO_CONFIG_INT(BcJellyTeeOthers, bc_jelly_tee_others, 0, 0, 1, CFGFLAG_CLIENT 
 MACRO_CONFIG_INT(BcJellyTeeStrength, bc_jelly_tee_strength, 500, 0, 1000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Strength of jelly tee deformation")
 MACRO_CONFIG_INT(BcJellyTeeDuration, bc_jelly_tee_duration, 30, 1, 500, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Duration of jelly tee deformation")
 
+// Player trail
+MACRO_CONFIG_INT(BcTrail, bc_trail, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable player trail effect")
+MACRO_CONFIG_INT(BcTrailOthers, bc_trail_others, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show player trail for other players")
+MACRO_CONFIG_INT(BcTrailMode, bc_trail_mode, 0, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Player trail mode (0=grenade, 1=invisible, 2=ninja)")
+
 // Chat bubbles
 MACRO_CONFIG_INT(BcChatBubbles, bc_chat_bubbles, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Toggle Chatbubbles")
 MACRO_CONFIG_INT(BcChatBubblesSelf, bc_chat_bubbles_self, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show Chatbubbles above you")

--- a/src/game/client/components/bestclient/r_trail.cpp
+++ b/src/game/client/components/bestclient/r_trail.cpp
@@ -1,0 +1,173 @@
+/* Copyright В© 2026 BestProject Team */
+#include "r_trail.h"
+
+#include <engine/shared/config.h>
+
+#include <game/client/components/effects.h>
+#include <game/client/gameclient.h>
+
+std::unique_ptr<CRTrail> rTrail;
+
+namespace
+{
+	float clampf(float v, float min, float max)
+	{
+		if(v < min)
+			return min;
+		if(v > max)
+			return max;
+		return v;
+	}
+
+	int clampi(int v, int min, int max)
+	{
+		if(v < min)
+			return min;
+		if(v > max)
+			return max;
+		return v;
+	}
+
+	constexpr float MIN_DELTA_TIME = 1.0f / 240.0f;
+	constexpr float MAX_DELTA_TIME = 1.0f / 20.0f;
+	constexpr float MIN_TRAIL_MOVEMENT = 0.75f;
+	constexpr float MAX_TRAIL_JUMP = 96.0f;
+	constexpr float TRAIL_SAMPLE_DISTANCE = 8.0f;
+	constexpr int MAX_TRAIL_SAMPLES = 24;
+
+	enum ETrailMode
+	{
+		TRAIL_MODE_GRENADE = 0,
+		TRAIL_MODE_GUN,
+		TRAIL_MODE_NINJA,
+	};
+
+	float sample_dist(int mode)
+	{
+		if(mode == TRAIL_MODE_GUN)
+			return 24.0f;
+		if(mode == TRAIL_MODE_NINJA)
+			return 14.0f;
+		return TRAIL_SAMPLE_DISTANCE;
+	}
+
+	void emit(CGameClient *pClient, int mode, vec2 pos, vec2 bodyPos, vec2 vel, float alpha, float timePassed)
+	{
+		if(pClient == nullptr)
+			return;
+
+		if(mode == TRAIL_MODE_GUN)
+		{
+			if(timePassed <= 0.0001f)
+				pClient->m_Effects.SparkleTrail(bodyPos, alpha);
+		}
+		else if(mode == TRAIL_MODE_NINJA)
+		{
+			if(timePassed <= 0.0001f)
+				pClient->m_Effects.PowerupShine(bodyPos, vec2(20.0f, 20.0f), alpha);
+		}
+		else
+		{
+			pClient->m_Effects.SmokeTrail(pos, vel * -1.0f, alpha, timePassed);
+		}
+	}
+} // namespace
+
+CRTrail::CRTrail(CGameClient *pClient) :
+	m_pClient(pClient)
+{
+}
+
+void CRTrail::Reset()
+{
+	for(auto &State : m_aStates)
+		State = CState();
+}
+
+bool CRTrail::IsEnabledFor(int id) const
+{
+	if(m_pClient == nullptr || !g_Config.m_BcTrail || id < 0 || id >= MAX_TRAIL_CLIENTS)
+		return false;
+
+	for(int i = 0; i < NUM_DUMMIES; ++i)
+	{
+		if(id == m_pClient->m_aLocalIds[i])
+			return true;
+	}
+
+	return g_Config.m_BcTrailOthers != 0;
+}
+
+CRTrail::CState *CRTrail::StateFor(int id)
+{
+	if(id < 0 || id >= MAX_TRAIL_CLIENTS)
+		return nullptr;
+	return &m_aStates[id];
+}
+
+void CRTrail::RenderPlayerTrail(int id, vec2 pos, vec2 bodyPos, vec2 vel, float alpha, float dt)
+{
+	if(m_pClient == nullptr || alpha <= 0.0f || id < 0)
+		return;
+
+	if(!IsEnabledFor(id))
+	{
+		CState *p = StateFor(id);
+		if(p)
+			*p = CState();
+		return;
+	}
+
+	CState *p = StateFor(id);
+	if(p == nullptr)
+		return;
+
+	dt = clampf(dt, MIN_DELTA_TIME, MAX_DELTA_TIME);
+
+	if(!p->m_Initialized)
+	{
+		p->m_LastPos = pos;
+		p->m_LastVel = vel;
+		p->m_Initialized = true;
+		return;
+	}
+
+	const vec2 d = pos - p->m_LastPos;
+	const float dist = length(d);
+	if(dist > MAX_TRAIL_JUMP)
+	{
+		p->m_LastPos = pos;
+		p->m_LastVel = vel;
+		return;
+	}
+
+	if(dist < MIN_TRAIL_MOVEMENT && length(vel) < 0.05f)
+	{
+		p->m_LastPos = pos;
+		p->m_LastVel = vel;
+		return;
+	}
+
+	const int mode = g_Config.m_BcTrailMode;
+	const float step = sample_dist(mode);
+	const int num = clampi((int)(dist / step), 1, MAX_TRAIL_SAMPLES);
+	const vec2 from = p->m_LastPos;
+	const vec2 oldVel = p->m_LastVel;
+
+	for(int i = 1; i <= num; ++i)
+	{
+		const float prevT = (float)(i - 1) / (float)num;
+		const float t = (float)i / (float)num;
+		const vec2 prevPos = mix(from, pos, prevT);
+		const vec2 ppos = mix(from, pos, t);
+		vec2 v = ppos - prevPos;
+		if(length(v) < 0.001f)
+			v = mix(oldVel, vel, t) * 0.12f;
+
+		const float tp = (1.0f - t) * dt;
+		emit(m_pClient, mode, ppos, bodyPos, v, alpha, tp);
+	}
+
+	p->m_LastPos = pos;
+	p->m_LastVel = vel;
+}

--- a/src/game/client/components/bestclient/r_trail.h
+++ b/src/game/client/components/bestclient/r_trail.h
@@ -1,0 +1,41 @@
+/* Copyright В© 2026 BestProject Team */
+#ifndef GAME_CLIENT_COMPONENTS_BESTCLIENT_R_TRAIL_H
+#define GAME_CLIENT_COMPONENTS_BESTCLIENT_R_TRAIL_H
+
+#include <base/vmath.h>
+
+#include <engine/shared/protocol.h>
+
+#include <array>
+#include <memory>
+
+class CGameClient;
+
+class CRTrail
+{
+public:
+	explicit CRTrail(CGameClient *pClient);
+
+	void Reset();
+	void RenderPlayerTrail(int id, vec2 pos, vec2 bodyPos, vec2 vel, float alpha, float dt);
+
+private:
+	static constexpr int MAX_TRAIL_CLIENTS = MAX_CLIENTS;
+
+	struct CState
+	{
+		vec2 m_LastPos = vec2(0.0f, 0.0f);
+		vec2 m_LastVel = vec2(0.0f, 0.0f);
+		bool m_Initialized = false;
+	};
+
+	CGameClient *m_pClient = nullptr;
+	std::array<CState, MAX_TRAIL_CLIENTS> m_aStates{};
+
+	bool IsEnabledFor(int id) const;
+	CState *StateFor(int id);
+};
+
+extern std::unique_ptr<CRTrail> rTrail;
+
+#endif

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -22,6 +22,7 @@
 #include <game/client/components/skins.h>
 #include <game/client/components/sounds.h>
 #include <game/client/components/bestclient/r_jelly.h>
+#include <game/client/components/bestclient/r_trail.h>
 #include <game/client/gameclient.h>
 #include <game/collision.h>
 #include <game/gamecore.h>
@@ -1092,6 +1093,8 @@ void CPlayers::RenderPlayer(
 	float TeeAnimScale, TeeBaseSize;
 	CRenderTools::GetRenderTeeAnimScaleAndBaseSize(&RenderInfo, TeeAnimScale, TeeBaseSize);
 	vec2 BodyPos = Position + vec2(State.GetBody()->m_X, State.GetBody()->m_Y) * TeeAnimScale;
+	if(rTrail)
+		rTrail->RenderPlayerTrail(ClientId, Position, BodyPos, Vel, Alpha, Client()->RenderFrameTime());
 	if(RenderInfo.m_TeeRenderFlags & TEE_EFFECT_FROZEN)
 	{
 		GameClient()->m_Effects.FreezingFlakes(BodyPos, vec2(32, 32), Alpha);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -43,6 +43,7 @@
 #include "race.h"
 #include "render.h"
 #include "components/bestclient/r_jelly.h"
+#include "components/bestclient/r_trail.h"
 
 #include <base/log.h>
 #include <base/math.h>
@@ -605,6 +606,7 @@ void CGameClient::OnConsoleInit()
 		pComponent->OnConsoleInit();
 
 	rJelly = std::make_unique<CRJelly>(this);
+	rTrail = std::make_unique<CRTrail>(this);
 
 	Console()->Chain("cl_languagefile", ConchainLanguageUpdate, this);
 
@@ -1147,6 +1149,8 @@ void CGameClient::OnReset()
 
 	if(rJelly)
 		rJelly->Reset();
+	if(rTrail)
+		rTrail->Reset();
 
 	for(auto &pComponent : m_vpAll)
 		pComponent->OnReset();


### PR DESCRIPTION
## Summary
- add a new player trail module
- add config options for enabling trails, showing trails for other players, and selecting a trail mode
- integrate trail rendering into player rendering
- register the new files in CMake

## Trail modes
- grenade - style smoke trail
<img width="843" height="754" alt="image" src="https://github.com/user-attachments/assets/65b10ff6-e157-4c02-b1ff-f1ff1f157395" />

- invincible - style sparkle trail
<img width="825" height="496" alt="image" src="https://github.com/user-attachments/assets/c0c2692c-2b2f-490b-806c-38caf0be6a77" />

- ninja - style powerup shine trail
<img width="1332" height="454" alt="image" src="https://github.com/user-attachments/assets/5bfac687-ca93-4ade-a588-ba40c5107c8e" />

