### PR TITLE
Fix local time display format (HH:MM:SS)

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -3278,7 +3278,7 @@ CUIRect CHud::GetLocalTimeRect(bool ForcePreview) const
 	const bool Seconds = g_Config.m_TcShowLocalTimeSeconds; // TClient
 
 	char aTimeStr[16];
-	str_timestamp_format(aTimeStr, sizeof(aTimeStr), Seconds ? "%H:%M.%S" : "%H:%M");
+	str_timestamp_format(aTimeStr, sizeof(aTimeStr), Seconds ? "%H:%M:%S" : "%H:%M");
 	const float FontSize = 5.0f * Scale;
 	const float Padding = 5.0f * Scale;
 	const float Width = std::round(TextRender()->TextBoundingBox(FontSize, aTimeStr).m_W);
@@ -3312,7 +3312,7 @@ void CHud::RenderLocalTime(bool ForcePreview)
 	const bool Seconds = g_Config.m_TcShowLocalTimeSeconds; // TClient
 
 	char aTimeStr[16];
-	str_timestamp_format(aTimeStr, sizeof(aTimeStr), Seconds ? "%H:%M.%S" : "%H:%M");
+	str_timestamp_format(aTimeStr, sizeof(aTimeStr), Seconds ? "%H:%M:%S" : "%H:%M");
 	const float FontSize = 5.0f * Scale;
 	const float Padding = 5.0f * Scale;
 	const float RectX = Rect.x;


### PR DESCRIPTION
Changed the local time display in the HUD from HH:MM.SS to the standard HH:MM:SS (src/game/client/components/hud.cpp)

Why it matters: HH:MM.SS is non-standard and can be misread (a dot typically implies a fractional part), while HH:MM:SS is the expected, clearer time format across UIs