### PR TITLE
Add configurable settings for freeview numpad camera

### DIFF
--- a/src/engine/shared/config_variables_bestclient.h
+++ b/src/engine/shared/config_variables_bestclient.h
@@ -39,6 +39,10 @@ MACRO_CONFIG_INT(BcCameraDrift, bc_camera_drift, 0, 0, 1, CFGFLAG_CLIENT | CFGFL
 MACRO_CONFIG_INT(BcCameraDriftAmount, bc_camera_drift_amount, 50, 1, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Amount of camera drift during demo playback")
 MACRO_CONFIG_INT(BcCameraDriftSmoothness, bc_camera_drift_smoothness, 20, 1, 20, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Smoothness of camera drift during demo playback")
 MACRO_CONFIG_INT(BcCameraDriftReverse, bc_camera_drift_reverse, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Reverse camera drift direction during demo playback")
+// Freeview Numpad Camera (spectator/demo playback)
+MACRO_CONFIG_INT(BcFreeviewNumpad, bc_freeview_numpad, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable numpad camera movement in freeview/spectator mode")
+MACRO_CONFIG_INT(BcFreeviewSpeed, bc_freeview_speed, 180, 1, 1000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Freeview camera movement speed")
+MACRO_CONFIG_INT(BcFreeviewSmoothness, bc_freeview_smoothness, 25, 1, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Freeview camera smoothness (acceleration)")
 
 // DynamicFov (demo playback only)
 MACRO_CONFIG_INT(BcDynamicFov, bc_dynamic_fov, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable dynamic FOV during demo playback")

--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -487,6 +487,32 @@ void CCamera::OnRender()
 	else
 		m_ForceFreeviewPos = m_Center;
 
+    if(m_CamType == CAMTYPE_SPEC && g_Config.m_BcFreeviewNumpad)
+{
+    const float SmoothFreeviewSpeed = (float)g_Config.m_BcFreeviewSpeed;
+    const float SmoothFreeviewAcceleration = g_Config.m_BcFreeviewSmoothness / 10.0f;
+    const float FrameTime = Client()->RenderFrameTime();
+    vec2 FreeviewMove = vec2(0.0f, 0.0f);
+    static vec2 SmoothFreeviewVelocity = vec2(0.0f, 0.0f);
+    if(Input()->KeyIsPressed(KEY_KP_4))
+        FreeviewMove.x -= 1.0f;
+    if(Input()->KeyIsPressed(KEY_KP_6))
+        FreeviewMove.x += 1.0f;
+    if(Input()->KeyIsPressed(KEY_KP_8))
+        FreeviewMove.y -= 1.0f;
+    if(Input()->KeyIsPressed(KEY_KP_2))
+        FreeviewMove.y += 1.0f;
+    const vec2 TargetVelocity = FreeviewMove * SmoothFreeviewSpeed;
+    SmoothFreeviewVelocity += (TargetVelocity - SmoothFreeviewVelocity) * minimum(FrameTime * SmoothFreeviewAcceleration, 1.0f);
+    if(absolute(SmoothFreeviewVelocity.x) < 0.1f && absolute(SmoothFreeviewVelocity.y) < 0.1f)
+        SmoothFreeviewVelocity = vec2(0.0f, 0.0f);
+    if(SmoothFreeviewVelocity.x != 0.0f || SmoothFreeviewVelocity.y != 0.0f)
+    {
+        m_ForceFreeviewPos = m_Center + SmoothFreeviewVelocity * FrameTime;
+        m_ForceFreeview = true;
+    }
+}
+
 	const int SpecId = GameClient()->m_Snap.m_SpecInfo.m_SpectatorId;
 
 	// start smoothing from the current position when the target changes


### PR DESCRIPTION
Motivation

Adds configurable console variables for the numpad freeview camera movement (previously added in #5), so the movement can be enabled/disabled and its speed/smoothness tuned without recompiling:
- bc_freeview_numpad (enable/disable)
- bc_freeview_speed (movement speed, 1-1000)
- bc_freeview_smoothness (acceleration/smoothing)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with ASan+UBSan or valgrind's memcheck (optional)
- [ ] I didn't use generative AI to generate more than single-line completions

AI was used to help write and debug the config variable integration and troubleshoot the build environment (Rust/dependency setup); the original camera movement logic itself was written by me in an earlier PR (#5).