### PR TITLE
Fix firing on its own and add optional reset inputs

### DIFF
--- a/src/engine/shared/config_variables_bestclient.h
+++ b/src/engine/shared/config_variables_bestclient.h
@@ -359,3 +359,6 @@ MACRO_CONFIG_INT(BcClansEnabled, bc_clans_enabled, 1, 0, 1, CFGFLAG_CLIENT | CFG
 MACRO_CONFIG_STR(BcClansApiUrl, bc_clans_api_url, 128, "https://clans.bestclient.fun", CFGFLAG_CLIENT | CFGFLAG_SAVE, "Clans API base URL (allowlisted)")
 MACRO_CONFIG_INT(BcClansAllowLocalDev, bc_clans_allow_local_dev, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Allow localhost clans API for development")
 MACRO_CONFIG_INT(BcClansUnreadBadge, bc_clans_unread_badge, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show unread badge on Clans menubar button")
+
+// Fast Practice
+MACRO_CONFIG_INT(BcFastPracticeResetInput, bc_fast_practice_reset_input, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable input reset on entering the mode")

--- a/src/game/client/components/bestclient/fast_practice.cpp
+++ b/src/game/client/components/bestclient/fast_practice.cpp
@@ -168,6 +168,11 @@ void CFastPractice::ResetPracticeState()
 	m_LastResolvedDummyInputConn = -1;
 	m_aHasServerLockedTargets.fill(false);
 	m_aServerLockedTargets.fill(ivec2(1, 0));
+	m_aServerLockedInputs.fill(CNetObj_PlayerInput{});
+	m_aStoredControlState.fill(SControlState{});
+	m_StoredDummyInput = {};
+	m_StoredDummyFire = 0;
+	m_HasStoredControlState = false;
 	m_MainAnchor = {};
 	m_DummyAnchor = {};
 	m_PracticeBaseWorld.Clear();
@@ -526,7 +531,7 @@ void CFastPractice::CaptureAnchorsFromSnapshot()
 	m_HasDummyAnchor = m_DummyAnchor.m_Valid;
 }
 
-bool CFastPractice::ApplyAnchorToCharacter(CGameWorld &World, const SAnchorData &Anchor) const
+bool CFastPractice::ApplyAnchorToCharacter(CGameWorld &World, const SAnchorData &Anchor, int InputConn) const
 {
 	if(!Anchor.m_Valid)
 		return false;
@@ -548,6 +553,8 @@ bool CFastPractice::ApplyAnchorToCharacter(CGameWorld &World, const SAnchorData 
 
 	CNetObj_PlayerInput NeutralInput = {};
 	NeutralInput.m_TargetY = -1;
+	if(!g_Config.m_BcFastPracticeResetInput && InputConn >= 0 && InputConn < NUM_DUMMIES)
+		NeutralInput.m_Fire = GameClient()->m_Controls.m_aInputData[InputConn].m_Fire;
 	pChar->SetInput(&NeutralInput);
 	pChar->m_CanMoveInFreeze = false;
 	return true;
@@ -585,6 +592,48 @@ void CFastPractice::ReleaseBufferedInputState()
 	GameClient()->m_DummyFire = 0;
 }
 
+void CFastPractice::RebaseBufferedFireState()
+{
+	for(int Conn = 0; Conn < NUM_DUMMIES; Conn++)
+	{
+		const int Fire = m_aHasServerLockedTargets[Conn] ? m_aServerLockedInputs[Conn].m_Fire : ReleasedFireState(GameClient()->m_Controls.m_aInputData[Conn].m_Fire);
+		GameClient()->m_Controls.m_aInputData[Conn].m_Fire = Fire;
+		GameClient()->m_Controls.m_aLastData[Conn].m_Fire = Fire;
+		GameClient()->m_Controls.m_aFastInput[Conn].m_Fire = Fire;
+	}
+
+	const int InactiveConn = g_Config.m_ClDummy ^ 1;
+	const int Fire = m_aHasServerLockedTargets[InactiveConn] ? m_aServerLockedInputs[InactiveConn].m_Fire : ReleasedFireState(GameClient()->m_DummyInput.m_Fire);
+	GameClient()->m_DummyInput.m_Fire = Fire;
+	GameClient()->m_HammerInput.m_Fire = Fire;
+}
+
+void CFastPractice::RestoreControlState()
+{
+	if(!m_HasStoredControlState)
+		return;
+
+	for(int Conn = 0; Conn < NUM_DUMMIES; Conn++)
+	{
+		const int InputPlayerFlags = GameClient()->m_Controls.m_aInputData[Conn].m_PlayerFlags;
+		const int LastPlayerFlags = GameClient()->m_Controls.m_aLastData[Conn].m_PlayerFlags;
+		GameClient()->m_Controls.m_aInputData[Conn] = m_aStoredControlState[Conn].m_Input;
+		GameClient()->m_Controls.m_aInputData[Conn].m_PlayerFlags = InputPlayerFlags;
+		GameClient()->m_Controls.m_aLastData[Conn] = m_aServerLockedInputs[Conn];
+		GameClient()->m_Controls.m_aLastData[Conn].m_PlayerFlags = LastPlayerFlags;
+		GameClient()->m_Controls.m_aLastData[Conn].m_Fire = m_aServerLockedInputs[Conn].m_Fire;
+		GameClient()->m_Controls.m_aInputDirectionLeft[Conn] = m_aStoredControlState[Conn].m_InputDirectionLeft;
+		GameClient()->m_Controls.m_aInputDirectionRight[Conn] = m_aStoredControlState[Conn].m_InputDirectionRight;
+		GameClient()->m_Controls.m_aSnapTapAppliedDirection[Conn] = m_aStoredControlState[Conn].m_SnapTapAppliedDirection;
+		GameClient()->m_Controls.m_aSnapTapLastPressedDirection[Conn] = m_aStoredControlState[Conn].m_SnapTapLastPressedDirection;
+		GameClient()->m_Controls.m_aSnapTapLastPressedTime[Conn] = m_aStoredControlState[Conn].m_SnapTapLastPressedTime;
+		GameClient()->m_Controls.m_aSnapTapPrevLeft[Conn] = m_aStoredControlState[Conn].m_SnapTapPrevLeft;
+		GameClient()->m_Controls.m_aSnapTapPrevRight[Conn] = m_aStoredControlState[Conn].m_SnapTapPrevRight;
+	}
+	GameClient()->m_DummyInput = m_StoredDummyInput;
+	GameClient()->m_DummyFire = m_StoredDummyFire;
+}
+
 void CFastPractice::InvalidateBufferedInputState()
 {
 	ReleaseBufferedInputState();
@@ -597,6 +646,7 @@ void CFastPractice::CaptureServerLockedTargets()
 	for(int Slot = 0; Slot < NUM_DUMMIES; Slot++)
 	{
 		const CNetObj_PlayerInput &Input = GameClient()->m_Controls.m_aInputData[Slot];
+		m_aStoredControlState[Slot].m_Input = Input;
 		int TargetX = Input.m_TargetX;
 		int TargetY = Input.m_TargetY;
 		if(TargetX == 0 && TargetY == 0)
@@ -605,7 +655,26 @@ void CFastPractice::CaptureServerLockedTargets()
 			TargetY = 0;
 		}
 		m_aServerLockedTargets[Slot] = ivec2(TargetX, TargetY);
+		m_aServerLockedInputs[Slot] = Input;
+		m_aServerLockedInputs[Slot].m_Fire = g_Config.m_BcFastPracticeResetInput ? ReleasedFireState(Input.m_Fire) : Input.m_Fire;
 		m_aHasServerLockedTargets[Slot] = true;
+	}
+
+	if(!g_Config.m_BcFastPracticeResetInput)
+	{
+		for(int Conn = 0; Conn < NUM_DUMMIES; Conn++)
+		{
+			m_aStoredControlState[Conn].m_InputDirectionLeft = GameClient()->m_Controls.m_aInputDirectionLeft[Conn];
+			m_aStoredControlState[Conn].m_InputDirectionRight = GameClient()->m_Controls.m_aInputDirectionRight[Conn];
+			m_aStoredControlState[Conn].m_SnapTapAppliedDirection = GameClient()->m_Controls.m_aSnapTapAppliedDirection[Conn];
+			m_aStoredControlState[Conn].m_SnapTapLastPressedDirection = GameClient()->m_Controls.m_aSnapTapLastPressedDirection[Conn];
+			m_aStoredControlState[Conn].m_SnapTapLastPressedTime = GameClient()->m_Controls.m_aSnapTapLastPressedTime[Conn];
+			m_aStoredControlState[Conn].m_SnapTapPrevLeft = GameClient()->m_Controls.m_aSnapTapPrevLeft[Conn];
+			m_aStoredControlState[Conn].m_SnapTapPrevRight = GameClient()->m_Controls.m_aSnapTapPrevRight[Conn];
+		}
+		m_StoredDummyInput = GameClient()->m_DummyInput;
+		m_StoredDummyFire = GameClient()->m_DummyFire;
+		m_HasStoredControlState = true;
 	}
 }
 
@@ -652,7 +721,9 @@ void CFastPractice::Enable()
 	if(m_RequireDummy && m_EnableDummyClientId >= 0)
 		if(CCharacter *pDummy = m_PracticeBaseWorld.GetCharacterById(m_EnableDummyClientId))
 			TrackSafeRescuePosition(m_EnableDummyClientId, pDummy);
-	ReleaseBufferedInputState();
+	if(g_Config.m_BcFastPracticeResetInput)
+		ReleaseBufferedInputState();
+	RebaseBufferedFireState();
 
 	// Snap renderer/camera prediction state to the local practice world immediately.
 	GameClient()->m_PredictedWorld.CopyWorldClean(&m_PracticeBaseWorld);
@@ -679,7 +750,12 @@ void CFastPractice::Disable()
 {
 	if(m_Enabled)
 		GameClient()->m_PredictedDummyId = -1;
-	ReleaseBufferedInputState();
+	if(g_Config.m_BcFastPracticeResetInput)
+		ReleaseBufferedInputState();
+	else
+		RestoreControlState();
+	if(g_Config.m_BcFastPracticeResetInput)
+		RebaseBufferedFireState();
 	m_aHasServerLockedTargets.fill(false);
 	ResetPracticeState();
 }
@@ -717,24 +793,48 @@ void CFastPractice::ResetPracticeToAnchor()
 		return;
 	}
 
-	if(!ApplyAnchorToCharacter(m_PracticeBaseWorld, m_MainAnchor))
+	int LocalInputSlot = m_LastResolvedLocalInputConn;
+	int DummyInputSlot = m_LastResolvedDummyInputConn;
+	if(!ResolveParticipantInputs(m_EnableLocalClientId, m_EnableDummyClientId, LocalInputSlot, DummyInputSlot))
 	{
 		Disable();
 		return;
 	}
 
-	if(m_RequireDummy && !ApplyAnchorToCharacter(m_PracticeBaseWorld, m_DummyAnchor))
+	if(!ApplyAnchorToCharacter(m_PracticeBaseWorld, m_MainAnchor, g_Config.m_ClDummy ^ LocalInputSlot))
+	{
+		Disable();
+		return;
+	}
+
+	if(m_RequireDummy && !ApplyAnchorToCharacter(m_PracticeBaseWorld, m_DummyAnchor, g_Config.m_ClDummy ^ DummyInputSlot))
 	{
 		Disable();
 		return;
 	}
 
 	if(CCharacter *pMain = m_PracticeBaseWorld.GetCharacterById(m_EnableLocalClientId))
+	{
 		NormalizeCharacterAfterReset(pMain, false);
+		if(!g_Config.m_BcFastPracticeResetInput)
+		{
+			CNetObj_PlayerInput Input = *pMain->LatestInput();
+			Input.m_Fire = GameClient()->m_Controls.m_aInputData[g_Config.m_ClDummy ^ LocalInputSlot].m_Fire;
+			pMain->SetInput(&Input);
+		}
+	}
 	if(m_RequireDummy)
 	{
 		if(CCharacter *pDummy = m_PracticeBaseWorld.GetCharacterById(m_EnableDummyClientId))
+		{
 			NormalizeCharacterAfterReset(pDummy, false);
+			if(!g_Config.m_BcFastPracticeResetInput)
+			{
+				CNetObj_PlayerInput Input = *pDummy->LatestInput();
+				Input.m_Fire = GameClient()->m_Controls.m_aInputData[g_Config.m_ClDummy ^ DummyInputSlot].m_Fire;
+				pDummy->SetInput(&Input);
+			}
+		}
 	}
 
 	m_PracticeBaseWorld.m_GameTick = Client()->PredGameTick(g_Config.m_ClDummy);
@@ -746,7 +846,9 @@ void CFastPractice::ResetPracticeToAnchor()
 			TrackSafeRescuePosition(m_EnableDummyClientId, pDummy);
 	m_SuppressFireOnNextPredictTick = true;
 	m_InputSuppressTicks = std::max(m_InputSuppressTicks, 2);
-	ReleaseBufferedInputState();
+	if(g_Config.m_BcFastPracticeResetInput)
+		ReleaseBufferedInputState();
+	RebaseBufferedFireState();
 
 	// Keep camera interpolation coherent after hard reset.
 	SyncPredictedWorldAfterPracticeCommand(m_EnableLocalClientId, m_EnableDummyClientId, m_PracticeBaseWorld.GetCharacterById(m_EnableLocalClientId), false);
@@ -760,13 +862,18 @@ void CFastPractice::PrepareInputForSend(int *pData, int Size, bool Dummy) const
 		return;
 
 	auto *pInput = reinterpret_cast<CNetObj_PlayerInput *>(pData);
-	NeutralizeInput(*pInput);
+	const int Slot = g_Config.m_ClDummy ^ (int)Dummy;
+	if(!g_Config.m_BcFastPracticeResetInput && Slot >= 0 && Slot < NUM_DUMMIES && m_aHasServerLockedTargets[Slot])
+		*pInput = m_aServerLockedInputs[Slot];
+	else
+		NeutralizeInput(*pInput);
+
 	// Never propagate shoot toggles to the server while fast practice is active.
-	pInput->m_Fire = 0;
+	if(g_Config.m_BcFastPracticeResetInput && Slot >= 0 && Slot < NUM_DUMMIES && m_aHasServerLockedTargets[Slot])
+		pInput->m_Fire = m_aServerLockedInputs[Slot].m_Fire;
 
 	// Keep server-side cursor fully locked per input stream so real world
 	// doesn't move when aiming inside local practice.
-	const int Slot = g_Config.m_ClDummy ^ (int)Dummy;
 	ivec2 LockedTarget = ivec2(1, 0);
 	if(Slot >= 0 && Slot < NUM_DUMMIES && m_aHasServerLockedTargets[Slot])
 		LockedTarget = m_aServerLockedTargets[Slot];
@@ -896,7 +1003,9 @@ bool CFastPractice::OverridePredict()
 				LocalClientId, DummyClientId, LocalInputConn, DummyInputConn);
 		m_SuppressFireOnNextPredictTick = true;
 		m_InputSuppressTicks = std::max(m_InputSuppressTicks, 2);
-		ReleaseBufferedInputState();
+		if(g_Config.m_BcFastPracticeResetInput)
+			ReleaseBufferedInputState();
+		RebaseBufferedFireState();
 	}
 
 	GameClient()->m_PredictedDummyId = DummyClientId;
@@ -997,7 +1106,7 @@ bool CFastPractice::OverridePredict()
 		const bool SuppressCooldownTick = Tick >= BaseGameTick + 1 && m_InputSuppressTicks > 0;
 		if(SuppressTransitionTick || SuppressCooldownTick)
 		{
-			if(pInputData)
+			if(g_Config.m_BcFastPracticeResetInput && pInputData)
 			{
 				LocalNeutralizedInput = *pInputData;
 				LocalNeutralizedInput.m_Fire = ReleasedFireState(pLocalChar->LatestInput()->m_Fire);
@@ -1006,13 +1115,25 @@ bool CFastPractice::OverridePredict()
 				LocalNeutralizedInput.m_PrevWeapon = 0;
 				pInputData = &LocalNeutralizedInput;
 			}
-			if(pDummyInputData)
+			else if(pInputData && pLocalChar)
+			{
+				LocalNeutralizedInput = *pInputData;
+				LocalNeutralizedInput.m_Fire = pLocalChar->LatestInput()->m_Fire;
+				pInputData = &LocalNeutralizedInput;
+			}
+			if(g_Config.m_BcFastPracticeResetInput && pDummyInputData)
 			{
 				DummyNeutralizedInput = *pDummyInputData;
 				DummyNeutralizedInput.m_Fire = ReleasedFireState(pDummyChar->LatestInput()->m_Fire);
 				DummyNeutralizedInput.m_WantedWeapon = 0;
 				DummyNeutralizedInput.m_NextWeapon = 0;
 				DummyNeutralizedInput.m_PrevWeapon = 0;
+				pDummyInputData = &DummyNeutralizedInput;
+			}
+			else if(pDummyInputData && pDummyChar)
+			{
+				DummyNeutralizedInput = *pDummyInputData;
+				DummyNeutralizedInput.m_Fire = pDummyChar->LatestInput()->m_Fire;
 				pDummyInputData = &DummyNeutralizedInput;
 			}
 			if(m_InputSuppressTicks > 0)

--- a/src/game/client/components/bestclient/fast_practice.h
+++ b/src/game/client/components/bestclient/fast_practice.h
@@ -102,6 +102,18 @@ private:
 		bool m_Finished = false;
 	};
 
+	struct SControlState
+	{
+		CNetObj_PlayerInput m_Input{};
+		int m_InputDirectionLeft = 0;
+		int m_InputDirectionRight = 0;
+		int m_SnapTapAppliedDirection = 0;
+		int m_SnapTapLastPressedDirection = 0;
+		int64_t m_SnapTapLastPressedTime = 0;
+		int m_SnapTapPrevLeft = 0;
+		int m_SnapTapPrevRight = 0;
+	};
+
 	bool m_Enabled = false;
 	bool m_RequireDummy = false;
 	int m_EnableLocalClientId = -1;
@@ -116,6 +128,11 @@ private:
 	int m_LastResolvedDummyInputConn = -1;
 	std::array<ivec2, NUM_DUMMIES> m_aServerLockedTargets{};
 	std::array<bool, NUM_DUMMIES> m_aHasServerLockedTargets{};
+	std::array<CNetObj_PlayerInput, NUM_DUMMIES> m_aServerLockedInputs{};
+	std::array<SControlState, NUM_DUMMIES> m_aStoredControlState{};
+	CNetObj_PlayerInput m_StoredDummyInput{};
+	int m_StoredDummyFire = 0;
+	bool m_HasStoredControlState = false;
 
 	SGhostData m_MainGhost;
 	SGhostData m_DummyGhost;
@@ -141,7 +158,7 @@ private:
 	void UpdateGhostForClientId(int ClientId, SGhostData &Ghost);
 	int ApplyVisualFastInputPrediction(int FinalTickRegular, int LocalClientId, int DummyClientId, int LocalInputConn, int DummyInputConn);
 	void CaptureAnchorsFromSnapshot();
-	bool ApplyAnchorToCharacter(CGameWorld &World, const SAnchorData &Anchor) const;
+	bool ApplyAnchorToCharacter(CGameWorld &World, const SAnchorData &Anchor, int InputConn) const;
 	bool InitPracticeWorld();
 	void PrunePracticeWorld(CGameWorld &World) const;
 	void ResetAttackTickHistory();
@@ -150,6 +167,8 @@ private:
 	void MaybePlayHammerHitEffect(CCharacter *pChar);
 	void RenderGhost(const SGhostData &Ghost, float Alpha) const;
 	void ReleaseBufferedInputState();
+	void RebaseBufferedFireState();
+	void RestoreControlState();
 
 	[[gnu::format(printf, 2, 3)]]
 	void EchoPractice(const char *pFormat, ...) const;

--- a/src/game/client/components/menus_bestclient.cpp
+++ b/src/game/client/components/menus_bestclient.cpp
@@ -2716,6 +2716,7 @@ void CMenus::RenderSettingsBestClientOthers(CUIRect MainView)
 		Ui()->DoScrollbarOption(&g_Config.m_BcAutoTeamLockDelay, &g_Config.m_BcAutoTeamLockDelay, &Button, Localize("Auto lock delay"), 0, 30, &CUi::ms_LinearScrollbarScale, 0, "s");
 	}
 	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_BcExtendZoom, Localize("Extend zoom (0.5 steps)"), &g_Config.m_BcExtendZoom, &MiscBlock, LineSize);
+	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_BcFastPracticeResetInput, Localize("Fast practice reset input"), &g_Config.m_BcFastPracticeResetInput, &MiscBlock, LineSize);
 	MiscBlock.HSplitTop(LineSize, &Button, &MiscBlock);
 	Ui()->DoScrollbarOption(&g_Config.m_UiScale, &g_Config.m_UiScale, &Button, Localize("UI scale"), 50, 110, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_DELAYUPDATE, "%");
 	MiscBlock.HSplitTop(LineSize, &Button, &MiscBlock);


### PR DESCRIPTION
Closes #13

<!-- What is the motivation for the changes of this pull request? -->
It fixes several bugs of fast practice mode. The main change is that the behavior of fast practice now matches that of /spec. Please review this PR and I will fix founded issues.

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
