### PR TITLE
fix: убрать перекрытие HUD музыкальным плеером

### DIFF
--- a/src/game/client/components/bestclient/music_player.cpp
+++ b/src/game/client/components/bestclient/music_player.cpp
@@ -25,6 +25,7 @@
 #include <game/client/components/hud_layout.h>
 #include <game/client/components/media_decoder.h>
 #include <game/client/components/scoreboard.h>
+#include <game/client/bc_ui_animations.h>
 #include <game/client/gameclient.h>
 #include <game/client/ui.h>
 #include <game/localization.h>
@@ -83,6 +84,7 @@ namespace
 	static constexpr float VISUALIZER_ATTACK_RATE = 46.0f;
 	static constexpr float VISUALIZER_RELEASE_RATE = 19.0f;
 	static constexpr int COVER_BAR_TINT_CELLS = MUSIC_PLAYER_MAX_VISUALIZER_BARS * COVER_BAR_SEGMENTS;
+	static constexpr int HUD_PUSH_ANIMATION_DURATION_MS = 420;
 
 	static CUIRect HudToUiRect(const CUIRect &HudRect, const CUIRect &UiScreen, float HudWidth, float HudHeight)
 	{
@@ -2435,6 +2437,7 @@ public:
 	int64_t m_LastVisualizerPollTick = 0;
 	float m_ExpandAnim = 0.0f;
 	float m_HoverAnim = 0.0f;
+	float m_HudPushAnim = 0.0f;
 	float m_VisualPositionMs = 0.0f;
 	std::string m_VisualTrackKey;
 	std::string m_PlaybackTrackKey;
@@ -2502,6 +2505,7 @@ public:
 	{
 		m_ExpandAnim = 0.0f;
 		m_HoverAnim = 0.0f;
+		m_HudPushAnim = 0.0f;
 		m_VisualPositionMs = 0.0f;
 		m_VisualTrackKey.clear();
 		m_aVisualizerLevels.fill(0.18f);
@@ -3258,10 +3262,14 @@ public:
 
 		const float SizeT = EaseInOutCubic(m_ExpandAnim);
 		const SMusicPlayerMetrics Metrics = ComputeMusicPlayerMetrics(Layout, Width, Height, SizeT, CompactTextSlotWidth, m_CompactTextSlotWidthAnim, MiniMode, ShowCover, TextScale);
+		if(BCUiAnimations::Enabled())
+			BCUiAnimations::UpdatePhase(m_HudPushAnim, m_ExpandAnim, Delta, BCUiAnimations::MsToSeconds(HUD_PUSH_ANIMATION_DURATION_MS));
+		else
+			m_HudPushAnim = m_ExpandAnim;
 		m_HudReservation.m_Rect = Metrics.m_ViewRect;
 		m_HudReservation.m_Visible = true;
 		m_HudReservation.m_Active = true;
-		m_HudReservation.m_PushAmount = 1.0f;
+		m_HudReservation.m_PushAmount = BCUiAnimations::EaseOutCubic(m_HudPushAnim);
 	}
 };
 
@@ -3307,36 +3315,59 @@ CMusicPlayer::SHudReservation CMusicPlayer::HudReservation() const
 	return m_pImpl->m_HudReservation;
 }
 
-float CMusicPlayer::GetHudPushOffsetForRect(const CUIRect &Rect, float CanvasWidth, float Padding) const
+vec2 CMusicPlayer::GetHudPushOffsetForRect(const CUIRect &Rect, float CanvasWidth, float CanvasHeight, float Padding) const
 {
 	const SHudReservation Reservation = HudReservation();
-	if(!Reservation.m_Visible || !Reservation.m_Active || Reservation.m_PushAmount <= 0.0f || Rect.w <= 0.0f || Rect.h <= 0.0f)
-		return 0.0f;
+	if(!Reservation.m_Visible || !Reservation.m_Active || Reservation.m_PushAmount <= 0.0f || Rect.w <= 0.0f || Rect.h <= 0.0f || CanvasWidth <= 0.0f || CanvasHeight <= 0.0f)
+		return vec2(0.0f, 0.0f);
 
 	const float Gap = maximum(Padding, 2.0f);
 	if(!RectsOverlap(Reservation.m_Rect, Rect, Gap))
-		return 0.0f;
+		return vec2(0.0f, 0.0f);
 
-	const float LeftX = std::clamp(Reservation.m_Rect.x - Gap - Rect.w, 0.0f, maximum(0.0f, CanvasWidth - Rect.w));
-	const float RightX = std::clamp(Reservation.m_Rect.x + Reservation.m_Rect.w + Gap, 0.0f, maximum(0.0f, CanvasWidth - Rect.w));
-	const float LeftOffset = LeftX - Rect.x;
-	const float RightOffset = RightX - Rect.x;
-	const float ChosenOffset = absolute(LeftOffset) <= absolute(RightOffset) ? LeftOffset : RightOffset;
-	return ChosenOffset * Reservation.m_PushAmount;
-}
+	struct SPushCandidate
+	{
+		vec2 m_Offset;
+		float m_Alignment;
+		float m_Distance;
+	};
+	std::array<SPushCandidate, 4> aCandidates{};
+	int CandidateCount = 0;
+	const vec2 RectCenter(Rect.x + Rect.w * 0.5f, Rect.y + Rect.h * 0.5f);
+	const vec2 PlayerCenter(Reservation.m_Rect.x + Reservation.m_Rect.w * 0.5f, Reservation.m_Rect.y + Reservation.m_Rect.h * 0.5f);
+	const vec2 Away = RectCenter - PlayerCenter;
+	const float AwayLength = length(Away);
 
-float CMusicPlayer::GetHudPushDownOffsetForRect(const CUIRect &Rect, float CanvasHeight, float Padding) const
-{
-	const SHudReservation Reservation = HudReservation();
-	if(!Reservation.m_Visible || !Reservation.m_Active || Reservation.m_PushAmount <= 0.0f || Rect.w <= 0.0f || Rect.h <= 0.0f)
-		return 0.0f;
+	auto AddCandidate = [&](vec2 Offset) {
+		const float TargetX = Rect.x + Offset.x;
+		const float TargetY = Rect.y + Offset.y;
+		if(TargetX < -0.001f || TargetY < -0.001f || TargetX + Rect.w > CanvasWidth + 0.001f || TargetY + Rect.h > CanvasHeight + 0.001f)
+			return;
 
-	const float Gap = maximum(Padding, 2.0f);
-	if(!RectsOverlap(Reservation.m_Rect, Rect, Gap))
-		return 0.0f;
+		const float Distance = length(Offset);
+		if(Distance <= 0.001f)
+			return;
 
-	const float TargetY = std::clamp(Reservation.m_Rect.y + Reservation.m_Rect.h + Gap, 0.0f, maximum(0.0f, CanvasHeight - Rect.h));
-	return maximum(0.0f, (TargetY - Rect.y) * Reservation.m_PushAmount);
+		const float Alignment = AwayLength > 0.001f ? dot(Offset / Distance, Away / AwayLength) : 0.0f;
+		aCandidates[CandidateCount++] = {Offset, Alignment, Distance};
+	};
+
+	AddCandidate(vec2(Reservation.m_Rect.x - Gap - Rect.w - Rect.x, 0.0f));
+	AddCandidate(vec2(Reservation.m_Rect.x + Reservation.m_Rect.w + Gap - Rect.x, 0.0f));
+	AddCandidate(vec2(0.0f, Reservation.m_Rect.y - Gap - Rect.h - Rect.y));
+	AddCandidate(vec2(0.0f, Reservation.m_Rect.y + Reservation.m_Rect.h + Gap - Rect.y));
+	if(CandidateCount == 0)
+		return vec2(0.0f, 0.0f);
+
+	const SPushCandidate *pBest = &aCandidates[0];
+	for(int i = 1; i < CandidateCount; ++i)
+	{
+		const SPushCandidate &Candidate = aCandidates[i];
+		if(Candidate.m_Distance < pBest->m_Distance - 0.001f ||
+			(Candidate.m_Distance <= pBest->m_Distance + 0.001f && Candidate.m_Alignment > pBest->m_Alignment))
+			pBest = &Candidate;
+	}
+	return pBest->m_Offset * Reservation.m_PushAmount;
 }
 
 bool CMusicPlayer::GetNowPlayingInfo(SNowPlayingInfo &Out) const

--- a/src/game/client/components/bestclient/music_player.h
+++ b/src/game/client/components/bestclient/music_player.h
@@ -42,8 +42,7 @@ public:
 	void OnWindowResize() override;
 
 	SHudReservation HudReservation() const;
-	float GetHudPushOffsetForRect(const CUIRect &Rect, float CanvasWidth, float Padding = 0.0f) const;
-	float GetHudPushDownOffsetForRect(const CUIRect &Rect, float CanvasHeight, float Padding = 0.0f) const;
+	vec2 GetHudPushOffsetForRect(const CUIRect &Rect, float CanvasWidth, float CanvasHeight, float Padding = 0.0f) const;
 	bool GetNowPlayingInfo(SNowPlayingInfo &Out) const;
 	bool GetHudThemeColor(ColorRGBA &Out, bool ForcePreview = false) const;
 	CUIRect GetHudEditorRect(bool ForcePreview = false) const;

--- a/src/game/client/components/bestclient/voice/voice.cpp
+++ b/src/game/client/components/bestclient/voice/voice.cpp
@@ -1620,8 +1620,9 @@ CUIRect CVoiceChat::GetHudMuteStatusIndicatorRect(float HudWidth, float HudHeigh
 	const bool MusicPlayerHudActive = !MusicPlayerComponentDisabled && g_Config.m_BcMusicPlayer != 0 && MusicReservation.m_Visible && MusicReservation.m_Active;
 	if(MusicPlayerHudActive)
 	{
-		const float Offset = GameClient()->m_MusicPlayer.GetHudPushOffsetForRect(Rect, HudWidth, 2.0f);
-		Rect.x += Offset;
+		const vec2 Offset = GameClient()->m_MusicPlayer.GetHudPushOffsetForRect(Rect, HudWidth, HudHeight, 2.0f);
+		Rect.x += Offset.x;
+		Rect.y += Offset.y;
 	}
 
 	Rect.x = std::clamp(Rect.x, 0.0f, maximum(0.0f, HudWidth - Rect.w));

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -51,6 +51,18 @@ namespace
 	constexpr float KEYSTROKES_MC_GAP = 8.0f;
 	constexpr int KEYSTROKES_MC_MAX_KEYS = 8;
 	constexpr int KEYSTROKES_STYLE_MINECRAFT = 1;
+
+	CUIRect PushHudRectFromMusicPlayer(CGameClient *pGameClient, CUIRect Rect, float HudWidth, float HudHeight, bool ForcePreview)
+	{
+		if(ForcePreview || pGameClient == nullptr || Rect.w <= 0.0f || Rect.h <= 0.0f)
+			return Rect;
+
+		const vec2 Offset = pGameClient->m_MusicPlayer.GetHudPushOffsetForRect(Rect, HudWidth, HudHeight, 2.0f);
+		Rect.x += Offset.x;
+		Rect.y += Offset.y;
+		return Rect;
+	}
+
 	void FormatPredictionTime(int64_t Milliseconds, bool ShowMillis, char *pBuf, size_t BufSize)
 	{
 		const int64_t TimeCentiseconds = maximum<int64_t>(0, (Milliseconds + 5) / 10);
@@ -813,8 +825,8 @@ CUIRect CHud::GetScoreHudRect(bool ForcePreview) const
 		RawRect = {m_Width - Width, 285.0f - Height, Width, Height, 5.0f * Scale};
 	else
 		RawRect = {Layout.m_X, Layout.m_Y, Width, Height, 5.0f * Scale};
-	const auto Rect = HudLayout::ClampRectToScreen(RawRect, m_Width, m_Height);
-	return {Rect.m_X, Rect.m_Y, Rect.m_W, Rect.m_H};
+	const auto ClampedRect = HudLayout::ClampRectToScreen(RawRect, m_Width, m_Height);
+	return PushHudRectFromMusicPlayer(GameClient(), {ClampedRect.m_X, ClampedRect.m_Y, ClampedRect.m_W, ClampedRect.m_H}, m_Width, m_Height, ForcePreview);
 }
 
 void CHud::RenderScoreHud(bool ForcePreview)
@@ -1285,7 +1297,9 @@ void CHud::RenderTextInfo()
 			str_format(aBuf, sizeof(aBuf), "%d / %d", NumInTeam - NumFrozen, NumInTeam);
 		else if(g_Config.m_TcShowFrozenText == 2)
 			str_format(aBuf, sizeof(aBuf), "%d / %d", NumFrozen, NumInTeam);
-		TextRender()->Text(m_Width / 2.0f - TextRender()->TextWidth(10.0f, aBuf) / 2.0f, 12.0f, 10.0f, aBuf);
+		const float TextWidth = TextRender()->TextWidth(10.0f, aBuf);
+		const CUIRect TextRect = PushHudRectFromMusicPlayer(GameClient(), {m_Width / 2.0f - TextWidth / 2.0f, 12.0f, TextWidth, 10.0f}, m_Width, m_Height, false);
+		TextRender()->Text(TextRect.x, TextRect.y, 10.0f, aBuf);
 	}
 }
 
@@ -1322,7 +1336,7 @@ CUIRect CHud::GetNotifyLastRect(bool ForcePreview) const
 	Rect.h = FontSize + 2.0f * Scale;
 	Rect.x = std::clamp(Rect.x, 0.0f, maximum(0.0f, m_Width - Rect.w));
 	Rect.y = std::clamp(Rect.y, 0.0f, maximum(0.0f, m_Height - Rect.h));
-	return Rect;
+	return PushHudRectFromMusicPlayer(GameClient(), Rect, m_Width, m_Height, ForcePreview);
 }
 
 void CHud::RenderNotifyLast(bool ForcePreview)
@@ -1409,7 +1423,7 @@ CUIRect CHud::GetFrozenHudRect(bool ForcePreview) const
 		Rect.x = Layout.m_X - TeeSize / 2.0f;
 	Rect.x = std::clamp(Rect.x, 0.0f, maximum(0.0f, m_Width - Rect.w));
 	Rect.y = std::clamp(Rect.y, 0.0f, maximum(0.0f, m_Height - Rect.h));
-	return Rect;
+	return PushHudRectFromMusicPlayer(GameClient(), Rect, m_Width, m_Height, ForcePreview);
 }
 
 void CHud::RenderFrozenHud(bool ForcePreview)
@@ -2756,8 +2770,8 @@ CUIRect CHud::GetSpectatorCountRect(bool ForcePreview)
 		RawRect = {X, Y, BoxWidth, BoxHeight, 5.0f * Scale};
 	}
 
-	const auto Rect = HudLayout::ClampRectToScreen(RawRect, m_Width, m_Height);
-	return {Rect.m_X, Rect.m_Y, Rect.m_W, Rect.m_H};
+	const auto ClampedRect = HudLayout::ClampRectToScreen(RawRect, m_Width, m_Height);
+	return PushHudRectFromMusicPlayer(GameClient(), {ClampedRect.m_X, ClampedRect.m_Y, ClampedRect.m_W, ClampedRect.m_H}, m_Width, m_Height, ForcePreview);
 }
 
 void CHud::RenderSpectatorCount(bool ForcePreview)
@@ -2841,8 +2855,8 @@ CUIRect CHud::GetDummyActionsRect(bool ForcePreview) const
 		RawRect = {X, Y, BoxWidth, BoxHeight, 5.0f * Scale};
 	}
 
-	const auto Rect = HudLayout::ClampRectToScreen(RawRect, m_Width, m_Height);
-	return {Rect.m_X, Rect.m_Y, Rect.m_W, Rect.m_H};
+	const auto ClampedRect = HudLayout::ClampRectToScreen(RawRect, m_Width, m_Height);
+	return PushHudRectFromMusicPlayer(GameClient(), {ClampedRect.m_X, ClampedRect.m_Y, ClampedRect.m_W, ClampedRect.m_H}, m_Width, m_Height, ForcePreview);
 }
 
 void CHud::RenderDummyActions(bool ForcePreview)
@@ -3135,8 +3149,8 @@ CUIRect CHud::GetMovementInformationRect(bool ForcePreview) const
 		RawRect = {X, Y, BoxWidth, BoxHeight, 5.0f * Scale};
 	}
 
-	const auto Rect = HudLayout::ClampRectToScreen(RawRect, m_Width, m_Height);
-	return {Rect.m_X, Rect.m_Y, Rect.m_W, Rect.m_H};
+	const auto ClampedRect = HudLayout::ClampRectToScreen(RawRect, m_Width, m_Height);
+	return PushHudRectFromMusicPlayer(GameClient(), {ClampedRect.m_X, ClampedRect.m_Y, ClampedRect.m_W, ClampedRect.m_H}, m_Width, m_Height, ForcePreview);
 }
 
 void CHud::RenderMovementInformation(bool ForcePreview)
@@ -3412,7 +3426,7 @@ CUIRect CHud::GetLocalTimeRect(bool ForcePreview) const
 	const float FontSize = 5.0f * Scale;
 	const float Padding = 5.0f * Scale;
 	const float Width = std::round(TextRender()->TextBoundingBox(FontSize, aTimeStr).m_W);
-	return {x - Width - Padding * 3.0f, y, Width + Padding * 2.0f, 12.5f * Scale};
+	return PushHudRectFromMusicPlayer(GameClient(), {x - Width - Padding * 3.0f, y, Width + Padding * 2.0f, 12.5f * Scale}, m_Width, m_Height, ForcePreview);
 }
 
 void CHud::RenderLocalTime(bool ForcePreview)
@@ -3424,9 +3438,6 @@ void CHud::RenderLocalTime(bool ForcePreview)
 
 	const auto Layout = HudLayout::Get(HudLayout::MODULE_LOCAL_TIME, m_Width, m_Height);
 	const float Scale = std::clamp(Layout.m_Scale / 100.0f, 0.25f, 3.0f);
-	const bool HasOverride = HudLayout::HasRuntimeOverride(HudLayout::MODULE_LOCAL_TIME);
-	const float x = HasOverride ? Layout.m_X : (m_Width / 7.0f) * 3.0f;
-	const float y = HasOverride ? Layout.m_Y : 0.0f;
 
 	const bool Seconds = g_Config.m_TcShowLocalTimeSeconds; // TClient
 
@@ -3434,16 +3445,12 @@ void CHud::RenderLocalTime(bool ForcePreview)
 	str_timestamp_format(aTimeStr, sizeof(aTimeStr), Seconds ? "%H:%M.%S" : "%H:%M");
 	const float FontSize = 5.0f * Scale;
 	const float Padding = 5.0f * Scale;
-	const float Width = std::round(TextRender()->TextBoundingBox(FontSize, aTimeStr).m_W);
 
-	const float RectX = x - Width - Padding * 3.0f;
-	const float RectY = y;
-	const float RectWidth = Width + Padding * 2.0f;
-	const float RectHeight = 12.5f * Scale;
-	const int Corners = HudLayout::BackgroundCorners(IGraphics::CORNER_ALL, RectX, RectY, RectWidth, RectHeight, m_Width, m_Height);
+	const CUIRect Rect = GetLocalTimeRect(ForcePreview);
+	const int Corners = HudLayout::BackgroundCorners(IGraphics::CORNER_ALL, Rect.x, Rect.y, Rect.w, Rect.h, m_Width, m_Height);
 	if(Layout.m_BackgroundEnabled)
-		Graphics()->DrawRect(RectX, RectY, RectWidth, RectHeight, color_cast<ColorRGBA>(ColorHSLA(Layout.m_BackgroundColor, true)), Corners, 3.75f * Scale);
-	TextRender()->Text(RectX + Padding, RectY + (RectHeight - FontSize) / 2.f, FontSize, aTimeStr, -1.0f);
+		Graphics()->DrawRect(Rect.x, Rect.y, Rect.w, Rect.h, color_cast<ColorRGBA>(ColorHSLA(Layout.m_BackgroundColor, true)), Corners, 3.75f * Scale);
+	TextRender()->Text(Rect.x + Padding, Rect.y + (Rect.h - FontSize) / 2.f, FontSize, aTimeStr, -1.0f);
 }
 
 bool CHud::RebuildFinishPredictionPathData() const
@@ -3951,7 +3958,7 @@ CUIRect CHud::GetFinishPredictionRect(bool ForcePreview) const
 	CUIRect Rect = {Layout.m_X, Layout.m_Y, RectWidth, RectHeight};
 	Rect.x = std::clamp(Rect.x, 0.0f, maximum(0.0f, m_Width - Rect.w));
 	Rect.y = std::clamp(Rect.y, 0.0f, maximum(0.0f, m_Height - Rect.h));
-	return Rect;
+	return PushHudRectFromMusicPlayer(GameClient(), Rect, m_Width, m_Height, ForcePreview);
 }
 
 void CHud::RenderFinishPrediction(bool ForcePreview)

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -352,6 +352,12 @@ CUIRect CVoting::GetHudRect(float HudWidth, float HudHeight, bool ForcePreview) 
 	CUIRect Rect = {HasOverride ? Layout.m_X : 0.0f, HasOverride ? Layout.m_Y : 60.0f, 120.0f * Scale, 38.0f * Scale};
 	Rect.x = std::clamp(Rect.x, 0.0f, std::max(0.0f, HudWidth - Rect.w));
 	Rect.y = std::clamp(Rect.y, 0.0f, std::max(0.0f, HudHeight - Rect.h));
+	if(!ForcePreview)
+	{
+		const vec2 Offset = GameClient()->m_MusicPlayer.GetHudPushOffsetForRect(Rect, HudWidth, HudHeight, 2.0f);
+		Rect.x += Offset.x;
+		Rect.y += Offset.y;
+	}
 	return Rect;
 }
 


### PR DESCRIPTION
## Что изменено

- При раскрытии музыкального плеера пересекающиеся элементы HUD временно сдвигаются в ближайшую свободную сторону.
- Смещение работает по четырём направлениям, учитывает границы экрана и плавно возвращает элементы обратно.
- Используется анимация 420 мс с кривой `EaseOutCubic`.

## Зачем

Раскрытый плеер перекрывал HUD при произвольном размещении элементов.

## Проверка

- `git diff --check`
- Скомпилированы изменённые C++-модули через Ninja.
- Конфигурация Linux-клиента: `VULKAN=ON`.