### PR TITLE
fix: плавный индикатор микрофона и HUD плеера

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,7 +391,9 @@ if(NOT MSVC AND NOT HAIKU)
     add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wno-format) # Don't warn about format strings in release mode since our `str_format` optimization is incompatible with it.
   endif()
   add_c_compiler_flag_if_supported(OUR_FLAGS_DEP -Wno-implicit-function-declaration)
-  add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wno-nullability-completeness) # Mac OS build on github
+	if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+		add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wno-nullability-completeness)
+	endif()
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wduplicated-cond)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wduplicated-branches)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wlogical-op)
@@ -429,10 +431,12 @@ function(set_glob VAR GLOBBING EXTS DIRECTORY) # ...
     list(APPEND FILES "${PROJECT_SOURCE_DIR}/${DIRECTORY}/${file}")
   endforeach()
 
-  if(NOT FILES STREQUAL GLOB_RESULT)
+  set(SORTED_FILES ${FILES})
+  list(SORT SORTED_FILES)
+  if(NOT SORTED_FILES STREQUAL GLOB_RESULT)
     message(AUTHOR_WARNING "${VAR} does not contain every file from directory ${DIRECTORY}")
     set(LIST_BUT_NOT_GLOB)
-    foreach(file ${FILES})
+    foreach(file ${SORTED_FILES})
       if(NOT file IN_LIST GLOB_RESULT)
         list(APPEND LIST_BUT_NOT_GLOB ${file})
       endif()
@@ -442,15 +446,12 @@ function(set_glob VAR GLOBBING EXTS DIRECTORY) # ...
     endif()
     set(GLOB_BUT_NOT_LIST)
     foreach(file ${GLOB_RESULT})
-      if(NOT file IN_LIST FILES)
+      if(NOT file IN_LIST SORTED_FILES)
         list(APPEND GLOB_BUT_NOT_LIST ${file})
       endif()
     endforeach()
     if(GLOB_BUT_NOT_LIST)
       message(AUTHOR_WARNING "Entries only present in ${DIRECTORY}: ${GLOB_BUT_NOT_LIST}")
-    endif()
-    if(NOT LIST_BUT_NOT_GLOB AND NOT GLOB_BUT_NOT_LIST)
-      message(AUTHOR_WARNING "${VAR} is not alphabetically sorted")
     endif()
   endif()
 
@@ -2680,6 +2681,7 @@ if(CLIENT)
   set_src(GAME_CLIENT GLOB_RECURSE src/game/client
     animstate.cpp
     animstate.h
+    bc_ui_animations.h
     component.cpp
     component.h
     components/background.cpp
@@ -2877,6 +2879,7 @@ if(CLIENT)
     components/bestclient/subsystem_runtime.h
     components/bestclient/translate.cpp
     components/bestclient/translate.h
+    components/bestclient/version.h
     components/bestclient/visualizer/analyzer.cpp
     components/bestclient/visualizer/analyzer.h
     components/bestclient/visualizer/service.cpp
@@ -3489,6 +3492,10 @@ endif()
 if(TOOLS)
   set(TARGETS_TOOLS)
   set_src(TOOLS_SRC GLOB src/tools
+    bestclient_updater.cpp
+    bestclient_updater_linux.cpp
+    bestclient_updater_linux_font.h
+    bestclient_updater_linux_fs.h
     config_common.h
     config_retrieve.cpp
     config_store.cpp
@@ -3515,6 +3522,9 @@ if(TOOLS)
     file(RELATIVE_PATH T "${PROJECT_SOURCE_DIR}/src/tools/" ${ABS_T})
     if(T MATCHES "\\.cpp$")
       string(REGEX REPLACE "\\.cpp$" "" TOOL "${T}")
+      if(TOOL MATCHES "^bestclient_updater(_linux)?$")
+        continue()
+      endif()
       set(TOOL_DEPS ${DEPS})
       set(TOOL_LIBS ${LIBS})
       unset(EXTRA_TOOL_SRC)

--- a/src/game/client/components/bestclient/music_player.cpp
+++ b/src/game/client/components/bestclient/music_player.cpp
@@ -1528,7 +1528,7 @@ namespace
 		return g_Config.m_BcMusicPlayerVisualizerRounding >= 100;
 	}
 
-	static bool IsTranslucentColorMode()
+	[[maybe_unused]] static bool IsTranslucentColorMode()
 	{
 		return g_Config.m_BcMusicPlayerColorMode == 2;
 	}

--- a/src/game/client/components/bestclient/music_player.cpp
+++ b/src/game/client/components/bestclient/music_player.cpp
@@ -25,6 +25,7 @@
 #include <game/client/components/hud_layout.h>
 #include <game/client/components/media_decoder.h>
 #include <game/client/components/scoreboard.h>
+#include <game/client/bc_ui_animations.h>
 #include <game/client/gameclient.h>
 #include <game/client/ui.h>
 #include <game/localization.h>
@@ -83,6 +84,7 @@ namespace
 	static constexpr float VISUALIZER_ATTACK_RATE = 46.0f;
 	static constexpr float VISUALIZER_RELEASE_RATE = 19.0f;
 	static constexpr int COVER_BAR_TINT_CELLS = MUSIC_PLAYER_MAX_VISUALIZER_BARS * COVER_BAR_SEGMENTS;
+	static constexpr int HUD_PUSH_ANIMATION_DURATION_MS = 420;
 
 	static CUIRect HudToUiRect(const CUIRect &HudRect, const CUIRect &UiScreen, float HudWidth, float HudHeight)
 	{
@@ -2435,6 +2437,7 @@ public:
 	int64_t m_LastVisualizerPollTick = 0;
 	float m_ExpandAnim = 0.0f;
 	float m_HoverAnim = 0.0f;
+	float m_HudPushAnim = 0.0f;
 	float m_VisualPositionMs = 0.0f;
 	std::string m_VisualTrackKey;
 	std::string m_PlaybackTrackKey;
@@ -2502,6 +2505,7 @@ public:
 	{
 		m_ExpandAnim = 0.0f;
 		m_HoverAnim = 0.0f;
+		m_HudPushAnim = 0.0f;
 		m_VisualPositionMs = 0.0f;
 		m_VisualTrackKey.clear();
 		m_aVisualizerLevels.fill(0.18f);
@@ -3258,10 +3262,14 @@ public:
 
 		const float SizeT = EaseInOutCubic(m_ExpandAnim);
 		const SMusicPlayerMetrics Metrics = ComputeMusicPlayerMetrics(Layout, Width, Height, SizeT, CompactTextSlotWidth, m_CompactTextSlotWidthAnim, MiniMode, ShowCover, TextScale);
+		if(BCUiAnimations::Enabled())
+			BCUiAnimations::UpdatePhase(m_HudPushAnim, m_ExpandAnim, Delta, BCUiAnimations::MsToSeconds(HUD_PUSH_ANIMATION_DURATION_MS));
+		else
+			m_HudPushAnim = m_ExpandAnim;
 		m_HudReservation.m_Rect = Metrics.m_ViewRect;
 		m_HudReservation.m_Visible = true;
 		m_HudReservation.m_Active = true;
-		m_HudReservation.m_PushAmount = 1.0f;
+		m_HudReservation.m_PushAmount = BCUiAnimations::EaseOutCubic(m_HudPushAnim);
 	}
 };
 
@@ -3307,36 +3315,59 @@ CMusicPlayer::SHudReservation CMusicPlayer::HudReservation() const
 	return m_pImpl->m_HudReservation;
 }
 
-float CMusicPlayer::GetHudPushOffsetForRect(const CUIRect &Rect, float CanvasWidth, float Padding) const
+vec2 CMusicPlayer::GetHudPushOffsetForRect(const CUIRect &Rect, float CanvasWidth, float CanvasHeight, float Padding) const
 {
 	const SHudReservation Reservation = HudReservation();
-	if(!Reservation.m_Visible || !Reservation.m_Active || Reservation.m_PushAmount <= 0.0f || Rect.w <= 0.0f || Rect.h <= 0.0f)
-		return 0.0f;
+	if(!Reservation.m_Visible || !Reservation.m_Active || Reservation.m_PushAmount <= 0.0f || Rect.w <= 0.0f || Rect.h <= 0.0f || CanvasWidth <= 0.0f || CanvasHeight <= 0.0f)
+		return vec2(0.0f, 0.0f);
 
 	const float Gap = maximum(Padding, 2.0f);
 	if(!RectsOverlap(Reservation.m_Rect, Rect, Gap))
-		return 0.0f;
+		return vec2(0.0f, 0.0f);
 
-	const float LeftX = std::clamp(Reservation.m_Rect.x - Gap - Rect.w, 0.0f, maximum(0.0f, CanvasWidth - Rect.w));
-	const float RightX = std::clamp(Reservation.m_Rect.x + Reservation.m_Rect.w + Gap, 0.0f, maximum(0.0f, CanvasWidth - Rect.w));
-	const float LeftOffset = LeftX - Rect.x;
-	const float RightOffset = RightX - Rect.x;
-	const float ChosenOffset = absolute(LeftOffset) <= absolute(RightOffset) ? LeftOffset : RightOffset;
-	return ChosenOffset * Reservation.m_PushAmount;
-}
+	struct SPushCandidate
+	{
+		vec2 m_Offset;
+		float m_Alignment;
+		float m_Distance;
+	};
+	std::array<SPushCandidate, 4> aCandidates{};
+	int CandidateCount = 0;
+	const vec2 RectCenter(Rect.x + Rect.w * 0.5f, Rect.y + Rect.h * 0.5f);
+	const vec2 PlayerCenter(Reservation.m_Rect.x + Reservation.m_Rect.w * 0.5f, Reservation.m_Rect.y + Reservation.m_Rect.h * 0.5f);
+	const vec2 Away = RectCenter - PlayerCenter;
+	const float AwayLength = length(Away);
 
-float CMusicPlayer::GetHudPushDownOffsetForRect(const CUIRect &Rect, float CanvasHeight, float Padding) const
-{
-	const SHudReservation Reservation = HudReservation();
-	if(!Reservation.m_Visible || !Reservation.m_Active || Reservation.m_PushAmount <= 0.0f || Rect.w <= 0.0f || Rect.h <= 0.0f)
-		return 0.0f;
+	auto AddCandidate = [&](vec2 Offset) {
+		const float TargetX = Rect.x + Offset.x;
+		const float TargetY = Rect.y + Offset.y;
+		if(TargetX < -0.001f || TargetY < -0.001f || TargetX + Rect.w > CanvasWidth + 0.001f || TargetY + Rect.h > CanvasHeight + 0.001f)
+			return;
 
-	const float Gap = maximum(Padding, 2.0f);
-	if(!RectsOverlap(Reservation.m_Rect, Rect, Gap))
-		return 0.0f;
+		const float Distance = length(Offset);
+		if(Distance <= 0.001f)
+			return;
 
-	const float TargetY = std::clamp(Reservation.m_Rect.y + Reservation.m_Rect.h + Gap, 0.0f, maximum(0.0f, CanvasHeight - Rect.h));
-	return maximum(0.0f, (TargetY - Rect.y) * Reservation.m_PushAmount);
+		const float Alignment = AwayLength > 0.001f ? dot(Offset / Distance, Away / AwayLength) : 0.0f;
+		aCandidates[CandidateCount++] = {Offset, Alignment, Distance};
+	};
+
+	AddCandidate(vec2(Reservation.m_Rect.x - Gap - Rect.w - Rect.x, 0.0f));
+	AddCandidate(vec2(Reservation.m_Rect.x + Reservation.m_Rect.w + Gap - Rect.x, 0.0f));
+	AddCandidate(vec2(0.0f, Reservation.m_Rect.y - Gap - Rect.h - Rect.y));
+	AddCandidate(vec2(0.0f, Reservation.m_Rect.y + Reservation.m_Rect.h + Gap - Rect.y));
+	if(CandidateCount == 0)
+		return vec2(0.0f, 0.0f);
+
+	const SPushCandidate *pBest = &aCandidates[0];
+	for(int i = 1; i < CandidateCount; ++i)
+	{
+		const SPushCandidate &Candidate = aCandidates[i];
+		if(Candidate.m_Distance < pBest->m_Distance - 0.001f ||
+			(Candidate.m_Distance <= pBest->m_Distance + 0.001f && Candidate.m_Alignment > pBest->m_Alignment))
+			pBest = &Candidate;
+	}
+	return pBest->m_Offset * Reservation.m_PushAmount;
 }
 
 bool CMusicPlayer::GetNowPlayingInfo(SNowPlayingInfo &Out) const

--- a/src/game/client/components/bestclient/music_player.h
+++ b/src/game/client/components/bestclient/music_player.h
@@ -42,8 +42,7 @@ public:
 	void OnWindowResize() override;
 
 	SHudReservation HudReservation() const;
-	float GetHudPushOffsetForRect(const CUIRect &Rect, float CanvasWidth, float Padding = 0.0f) const;
-	float GetHudPushDownOffsetForRect(const CUIRect &Rect, float CanvasHeight, float Padding = 0.0f) const;
+	vec2 GetHudPushOffsetForRect(const CUIRect &Rect, float CanvasWidth, float CanvasHeight, float Padding = 0.0f) const;
 	bool GetNowPlayingInfo(SNowPlayingInfo &Out) const;
 	bool GetHudThemeColor(ColorRGBA &Out, bool ForcePreview = false) const;
 	CUIRect GetHudEditorRect(bool ForcePreview = false) const;

--- a/src/game/client/components/bestclient/voice/voice.cpp
+++ b/src/game/client/components/bestclient/voice/voice.cpp
@@ -1226,7 +1226,12 @@ void CVoiceChat::RenderMenuSettingsBlock(const CUIRect &View, float RevealPhase)
 		MeterBar.Draw(ColorRGBA(0.02f, 0.02f, 0.03f, 0.28f), IGraphics::CORNER_ALL, 3.0f);
 		CUIRect Fill = MeterBar;
 		Fill.w *= std::clamp(m_MicLevel, 0.0f, 1.0f);
-		Fill.Draw(ColorRGBA(0.30f, 0.70f, 0.42f, 0.78f), IGraphics::CORNER_ALL, 3.0f);
+		if(Fill.w > 0.0f)
+		{
+			const float Rounding = minimum(3.0f, minimum(Fill.w * 0.5f, Fill.h * 0.5f));
+			const int Corners = Fill.w >= MeterBar.w ? IGraphics::CORNER_ALL : IGraphics::CORNER_L;
+			Fill.Draw(ColorRGBA(0.30f, 0.70f, 0.42f, 0.78f), Corners, Rounding);
+		}
 	}
 
 	AddExpandedSpacing(3.0f);

--- a/src/game/client/components/bestclient/voice/voice.cpp
+++ b/src/game/client/components/bestclient/voice/voice.cpp
@@ -1625,8 +1625,9 @@ CUIRect CVoiceChat::GetHudMuteStatusIndicatorRect(float HudWidth, float HudHeigh
 	const bool MusicPlayerHudActive = !MusicPlayerComponentDisabled && g_Config.m_BcMusicPlayer != 0 && MusicReservation.m_Visible && MusicReservation.m_Active;
 	if(MusicPlayerHudActive)
 	{
-		const float Offset = GameClient()->m_MusicPlayer.GetHudPushOffsetForRect(Rect, HudWidth, 2.0f);
-		Rect.x += Offset;
+		const vec2 Offset = GameClient()->m_MusicPlayer.GetHudPushOffsetForRect(Rect, HudWidth, HudHeight, 2.0f);
+		Rect.x += Offset.x;
+		Rect.y += Offset.y;
 	}
 
 	Rect.x = std::clamp(Rect.x, 0.0f, maximum(0.0f, HudWidth - Rect.w));

--- a/src/game/client/components/bestclient/voice/voice.cpp
+++ b/src/game/client/components/bestclient/voice/voice.cpp
@@ -556,6 +556,8 @@ void CVoiceChat::OnReset()
 	m_AutoActivationUntilTick = 0;
 	m_SendSequence = 0;
 	m_MicLevel = 0.0f;
+	m_MicLevelTarget = 0.0f;
+	m_MicLevelVisible = false;
 	m_MicLimiterGain = 1.0f;
 	m_AutoNsNoiseFloor = 0.0f;
 	m_AutoNsGate = 1.0f;
@@ -1224,8 +1226,16 @@ void CVoiceChat::RenderMenuSettingsBlock(const CUIRect &View, float RevealPhase)
 		MeterBarWrap.VSplitLeft(6.0f, nullptr, &MeterBarWrap);
 		MeterBarWrap.HMargin(2.0f, &MeterBar);
 		MeterBar.Draw(ColorRGBA(0.02f, 0.02f, 0.03f, 0.28f), IGraphics::CORNER_ALL, 3.0f);
+		const float Delta = std::clamp(Client()->RenderFrameTime(), 0.0f, 0.1f);
+		const float FollowSpeed = m_MicLevelTarget > m_MicLevel ? 32.0f : 6.0f;
+		m_MicLevel = mix(m_MicLevel, m_MicLevelTarget, 1.0f - std::exp(-FollowSpeed * Delta));
+		if(m_MicLevel >= 0.015f)
+			m_MicLevelVisible = true;
+		else if(m_MicLevel <= 0.006f)
+			m_MicLevelVisible = false;
+		const float DisplayLevel = m_MicLevelVisible ? std::clamp((m_MicLevel - 0.006f) / 0.994f, 0.0f, 1.0f) : 0.0f;
 		CUIRect Fill = MeterBar;
-		Fill.w *= std::clamp(m_MicLevel, 0.0f, 1.0f);
+		Fill.w *= DisplayLevel;
 		if(Fill.w > 0.0f)
 		{
 			const float Rounding = minimum(3.0f, minimum(Fill.w * 0.5f, Fill.h * 0.5f));
@@ -3057,7 +3067,7 @@ void CVoiceChat::ProcessCapture()
 		m_AutoHpfPrevIn = 0.0f;
 		m_AutoHpfPrevOut = 0.0f;
 		m_AutoCompEnv = 0.0f;
-		m_MicLevel = mix(m_MicLevel, 0.0f, 0.25f);
+		m_MicLevelTarget = mix(m_MicLevelTarget, 0.0f, 0.25f);
 		m_CapturePcm.Clear();
 		m_MicMonitorPcm.Clear();
 		if(SDL_GetQueuedAudioSize(m_CaptureDevice) > 0)
@@ -3074,7 +3084,7 @@ void CVoiceChat::ProcessCapture()
 		m_AutoHpfPrevIn = 0.0f;
 		m_AutoHpfPrevOut = 0.0f;
 		m_AutoCompEnv = 0.0f;
-		m_MicLevel = mix(m_MicLevel, 0.0f, 0.25f);
+		m_MicLevelTarget = mix(m_MicLevelTarget, 0.0f, 0.25f);
 		if(SDL_GetQueuedAudioSize(m_CaptureDevice) > 0)
 			SDL_ClearQueuedAudio(m_CaptureDevice);
 		return;
@@ -3131,7 +3141,7 @@ void CVoiceChat::ProcessCapture()
 			m_LastProcessCaptureTick = Now;
 		}
 
-		m_MicLevel = mix(m_MicLevel, 0.0f, 0.08f);
+		m_MicLevelTarget = mix(m_MicLevelTarget, 0.0f, 0.08f);
 	}
 
 	while(m_CapturePcm.Size() >= (size_t)BestClientVoice::FRAME_SIZE)
@@ -3189,9 +3199,9 @@ void CVoiceChat::ProcessCapture()
 		AvgLevel /= BestClientVoice::FRAME_SIZE;
 		const float LevelLinear = std::clamp((float)AvgLevel / 32767.0f, 0.0f, 1.0f);
 		const float PeakLinear = std::clamp((float)Peak / 32767.0f, 0.0f, 1.0f);
-		const float MicLevelScale = 2.0f;
+		const float MicLevelScale = 4.0f;
 		const float LevelLinearScaled = std::clamp(LevelLinear * MicLevelScale, 0.0f, 1.0f);
-		m_MicLevel = mix(m_MicLevel, LevelLinearScaled, 0.2f);
+		m_MicLevelTarget = LevelLinearScaled;
 
 		if(g_Config.m_BcVoiceChatMicCheck)
 			m_MicMonitorPcm.PushBack(aFrame, BestClientVoice::FRAME_SIZE);

--- a/src/game/client/components/bestclient/voice/voice.h
+++ b/src/game/client/components/bestclient/voice/voice.h
@@ -235,6 +235,8 @@ private:
 	bool m_PushToTalkPressed = false;
 	int64_t m_AutoActivationUntilTick = 0;
 	float m_MicLevel = 0.0f;
+	float m_MicLevelTarget = 0.0f;
+	bool m_MicLevelVisible = false;
 	float m_MicLimiterGain = 1.0f;
 	float m_AutoNsNoiseFloor = 0.0f;
 	float m_AutoNsGate = 1.0f;

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -51,6 +51,18 @@ namespace
 	constexpr float KEYSTROKES_MC_GAP = 8.0f;
 	constexpr int KEYSTROKES_MC_MAX_KEYS = 8;
 	constexpr int KEYSTROKES_STYLE_MINECRAFT = 1;
+
+	CUIRect PushHudRectFromMusicPlayer(CGameClient *pGameClient, CUIRect Rect, float HudWidth, float HudHeight, bool ForcePreview)
+	{
+		if(ForcePreview || pGameClient == nullptr || Rect.w <= 0.0f || Rect.h <= 0.0f)
+			return Rect;
+
+		const vec2 Offset = pGameClient->m_MusicPlayer.GetHudPushOffsetForRect(Rect, HudWidth, HudHeight, 2.0f);
+		Rect.x += Offset.x;
+		Rect.y += Offset.y;
+		return Rect;
+	}
+
 	void FormatPredictionTime(int64_t Milliseconds, bool ShowMillis, char *pBuf, size_t BufSize)
 	{
 		const int64_t TimeCentiseconds = maximum<int64_t>(0, (Milliseconds + 5) / 10);
@@ -813,8 +825,8 @@ CUIRect CHud::GetScoreHudRect(bool ForcePreview) const
 		RawRect = {m_Width - Width, 285.0f - Height, Width, Height, 5.0f * Scale};
 	else
 		RawRect = {Layout.m_X, Layout.m_Y, Width, Height, 5.0f * Scale};
-	const auto Rect = HudLayout::ClampRectToScreen(RawRect, m_Width, m_Height);
-	return {Rect.m_X, Rect.m_Y, Rect.m_W, Rect.m_H};
+	const auto ClampedRect = HudLayout::ClampRectToScreen(RawRect, m_Width, m_Height);
+	return PushHudRectFromMusicPlayer(GameClient(), {ClampedRect.m_X, ClampedRect.m_Y, ClampedRect.m_W, ClampedRect.m_H}, m_Width, m_Height, ForcePreview);
 }
 
 void CHud::RenderScoreHud(bool ForcePreview)
@@ -1285,7 +1297,9 @@ void CHud::RenderTextInfo()
 			str_format(aBuf, sizeof(aBuf), "%d / %d", NumInTeam - NumFrozen, NumInTeam);
 		else if(g_Config.m_TcShowFrozenText == 2)
 			str_format(aBuf, sizeof(aBuf), "%d / %d", NumFrozen, NumInTeam);
-		TextRender()->Text(m_Width / 2.0f - TextRender()->TextWidth(10.0f, aBuf) / 2.0f, 12.0f, 10.0f, aBuf);
+		const float TextWidth = TextRender()->TextWidth(10.0f, aBuf);
+		const CUIRect TextRect = PushHudRectFromMusicPlayer(GameClient(), {m_Width / 2.0f - TextWidth / 2.0f, 12.0f, TextWidth, 10.0f}, m_Width, m_Height, false);
+		TextRender()->Text(TextRect.x, TextRect.y, 10.0f, aBuf);
 	}
 }
 
@@ -1322,7 +1336,7 @@ CUIRect CHud::GetNotifyLastRect(bool ForcePreview) const
 	Rect.h = FontSize + 2.0f * Scale;
 	Rect.x = std::clamp(Rect.x, 0.0f, maximum(0.0f, m_Width - Rect.w));
 	Rect.y = std::clamp(Rect.y, 0.0f, maximum(0.0f, m_Height - Rect.h));
-	return Rect;
+	return PushHudRectFromMusicPlayer(GameClient(), Rect, m_Width, m_Height, ForcePreview);
 }
 
 void CHud::RenderNotifyLast(bool ForcePreview)
@@ -1409,7 +1423,7 @@ CUIRect CHud::GetFrozenHudRect(bool ForcePreview) const
 		Rect.x = Layout.m_X - TeeSize / 2.0f;
 	Rect.x = std::clamp(Rect.x, 0.0f, maximum(0.0f, m_Width - Rect.w));
 	Rect.y = std::clamp(Rect.y, 0.0f, maximum(0.0f, m_Height - Rect.h));
-	return Rect;
+	return PushHudRectFromMusicPlayer(GameClient(), Rect, m_Width, m_Height, ForcePreview);
 }
 
 void CHud::RenderFrozenHud(bool ForcePreview)
@@ -2756,8 +2770,8 @@ CUIRect CHud::GetSpectatorCountRect(bool ForcePreview)
 		RawRect = {X, Y, BoxWidth, BoxHeight, 5.0f * Scale};
 	}
 
-	const auto Rect = HudLayout::ClampRectToScreen(RawRect, m_Width, m_Height);
-	return {Rect.m_X, Rect.m_Y, Rect.m_W, Rect.m_H};
+	const auto ClampedRect = HudLayout::ClampRectToScreen(RawRect, m_Width, m_Height);
+	return PushHudRectFromMusicPlayer(GameClient(), {ClampedRect.m_X, ClampedRect.m_Y, ClampedRect.m_W, ClampedRect.m_H}, m_Width, m_Height, ForcePreview);
 }
 
 void CHud::RenderSpectatorCount(bool ForcePreview)
@@ -2841,8 +2855,8 @@ CUIRect CHud::GetDummyActionsRect(bool ForcePreview) const
 		RawRect = {X, Y, BoxWidth, BoxHeight, 5.0f * Scale};
 	}
 
-	const auto Rect = HudLayout::ClampRectToScreen(RawRect, m_Width, m_Height);
-	return {Rect.m_X, Rect.m_Y, Rect.m_W, Rect.m_H};
+	const auto ClampedRect = HudLayout::ClampRectToScreen(RawRect, m_Width, m_Height);
+	return PushHudRectFromMusicPlayer(GameClient(), {ClampedRect.m_X, ClampedRect.m_Y, ClampedRect.m_W, ClampedRect.m_H}, m_Width, m_Height, ForcePreview);
 }
 
 void CHud::RenderDummyActions(bool ForcePreview)
@@ -3135,8 +3149,8 @@ CUIRect CHud::GetMovementInformationRect(bool ForcePreview) const
 		RawRect = {X, Y, BoxWidth, BoxHeight, 5.0f * Scale};
 	}
 
-	const auto Rect = HudLayout::ClampRectToScreen(RawRect, m_Width, m_Height);
-	return {Rect.m_X, Rect.m_Y, Rect.m_W, Rect.m_H};
+	const auto ClampedRect = HudLayout::ClampRectToScreen(RawRect, m_Width, m_Height);
+	return PushHudRectFromMusicPlayer(GameClient(), {ClampedRect.m_X, ClampedRect.m_Y, ClampedRect.m_W, ClampedRect.m_H}, m_Width, m_Height, ForcePreview);
 }
 
 void CHud::RenderMovementInformation(bool ForcePreview)
@@ -3412,7 +3426,7 @@ CUIRect CHud::GetLocalTimeRect(bool ForcePreview) const
 	const float FontSize = 5.0f * Scale;
 	const float Padding = 5.0f * Scale;
 	const float Width = std::round(TextRender()->TextBoundingBox(FontSize, aTimeStr).m_W);
-	return {x - Width - Padding * 3.0f, y, Width + Padding * 2.0f, 12.5f * Scale};
+	return PushHudRectFromMusicPlayer(GameClient(), {x - Width - Padding * 3.0f, y, Width + Padding * 2.0f, 12.5f * Scale}, m_Width, m_Height, ForcePreview);
 }
 
 void CHud::RenderLocalTime(bool ForcePreview)
@@ -3424,9 +3438,6 @@ void CHud::RenderLocalTime(bool ForcePreview)
 
 	const auto Layout = HudLayout::Get(HudLayout::MODULE_LOCAL_TIME, m_Width, m_Height);
 	const float Scale = std::clamp(Layout.m_Scale / 100.0f, 0.25f, 3.0f);
-	const bool HasOverride = HudLayout::HasRuntimeOverride(HudLayout::MODULE_LOCAL_TIME);
-	const float x = HasOverride ? Layout.m_X : (m_Width / 7.0f) * 3.0f;
-	const float y = HasOverride ? Layout.m_Y : 0.0f;
 
 	const bool Seconds = g_Config.m_TcShowLocalTimeSeconds; // TClient
 
@@ -3434,16 +3445,12 @@ void CHud::RenderLocalTime(bool ForcePreview)
 	str_timestamp_format(aTimeStr, sizeof(aTimeStr), Seconds ? "%H:%M.%S" : "%H:%M");
 	const float FontSize = 5.0f * Scale;
 	const float Padding = 5.0f * Scale;
-	const float Width = std::round(TextRender()->TextBoundingBox(FontSize, aTimeStr).m_W);
 
-	const float RectX = x - Width - Padding * 3.0f;
-	const float RectY = y;
-	const float RectWidth = Width + Padding * 2.0f;
-	const float RectHeight = 12.5f * Scale;
-	const int Corners = HudLayout::BackgroundCorners(IGraphics::CORNER_ALL, RectX, RectY, RectWidth, RectHeight, m_Width, m_Height);
+	const CUIRect Rect = GetLocalTimeRect(ForcePreview);
+	const int Corners = HudLayout::BackgroundCorners(IGraphics::CORNER_ALL, Rect.x, Rect.y, Rect.w, Rect.h, m_Width, m_Height);
 	if(Layout.m_BackgroundEnabled)
-		Graphics()->DrawRect(RectX, RectY, RectWidth, RectHeight, color_cast<ColorRGBA>(ColorHSLA(Layout.m_BackgroundColor, true)), Corners, 3.75f * Scale);
-	TextRender()->Text(RectX + Padding, RectY + (RectHeight - FontSize) / 2.f, FontSize, aTimeStr, -1.0f);
+		Graphics()->DrawRect(Rect.x, Rect.y, Rect.w, Rect.h, color_cast<ColorRGBA>(ColorHSLA(Layout.m_BackgroundColor, true)), Corners, 3.75f * Scale);
+	TextRender()->Text(Rect.x + Padding, Rect.y + (Rect.h - FontSize) / 2.f, FontSize, aTimeStr, -1.0f);
 }
 
 bool CHud::RebuildFinishPredictionPathData() const
@@ -3951,7 +3958,7 @@ CUIRect CHud::GetFinishPredictionRect(bool ForcePreview) const
 	CUIRect Rect = {Layout.m_X, Layout.m_Y, RectWidth, RectHeight};
 	Rect.x = std::clamp(Rect.x, 0.0f, maximum(0.0f, m_Width - Rect.w));
 	Rect.y = std::clamp(Rect.y, 0.0f, maximum(0.0f, m_Height - Rect.h));
-	return Rect;
+	return PushHudRectFromMusicPlayer(GameClient(), Rect, m_Width, m_Height, ForcePreview);
 }
 
 void CHud::RenderFinishPrediction(bool ForcePreview)

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -870,8 +870,8 @@ void CHud::RenderScoreHud(bool ForcePreview)
 			const std::vector<STextColorSplit> vGradientSplits = CBcGradient::BuildAnimatedTextSplits(pName, Id, GameClient(), Phase);
 			if(!vGradientSplits.empty())
 			{
-				for(const STextColorSplit &Split : vGradientSplits)
-					Cursor.m_vColorSplits.emplace_back(Cursor.m_CharCount + Split.m_CharIndex, Split.m_Length, Split.m_Color);
+				for(const STextColorSplit &GradientSplit : vGradientSplits)
+					Cursor.m_vColorSplits.emplace_back(Cursor.m_CharCount + GradientSplit.m_CharIndex, GradientSplit.m_Length, GradientSplit.m_Color);
 				TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 			}
 		}

--- a/src/game/client/components/menus_clans.cpp
+++ b/src/game/client/components/menus_clans.cpp
@@ -2212,7 +2212,7 @@ void CMenus::RenderClansPreview(CUIRect MainView)
 void CMenus::RenderClansApplications(CUIRect MainView)
 {
 	CClans &Clans = GameClient()->m_Clans;
-	CUIRect Top, Label, Button, BackBtn, RefreshBtn;
+	CUIRect Top, Label, BackBtn, RefreshBtn;
 	MainView.HSplitTop(28.0f, &Top, &MainView);
 	Top.VSplitRight(28.0f, &Top, &RefreshBtn);
 	Top.VSplitRight(4.0f, &Top, nullptr);

--- a/src/game/client/components/tclient/bg_draw.cpp
+++ b/src/game/client/components/tclient/bg_draw.cpp
@@ -516,8 +516,8 @@ void CBgDraw::OnRender()
 				if(Item.m_Killed)
 					continue;
 				// Don't erase items that are currently being drawn
-				if(std::any_of(std::begin(m_apActiveItems), std::end(m_apActiveItems), [&](const std::optional<CBgDrawItem *> &ActiveItem) {
-					   return ActiveItem.value_or(nullptr) == &Item;
+				if(std::any_of(std::begin(m_apActiveItems), std::end(m_apActiveItems), [&](const std::optional<CBgDrawItem *> &ActiveDrawItem) {
+					   return ActiveDrawItem.value_or(nullptr) == &Item;
 				   }))
 					continue;
 				// Erase only the covered part, keeping the surviving pieces

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -352,6 +352,12 @@ CUIRect CVoting::GetHudRect(float HudWidth, float HudHeight, bool ForcePreview) 
 	CUIRect Rect = {HasOverride ? Layout.m_X : 0.0f, HasOverride ? Layout.m_Y : 60.0f, 120.0f * Scale, 38.0f * Scale};
 	Rect.x = std::clamp(Rect.x, 0.0f, std::max(0.0f, HudWidth - Rect.w));
 	Rect.y = std::clamp(Rect.y, 0.0f, std::max(0.0f, HudHeight - Rect.h));
+	if(!ForcePreview)
+	{
+		const vec2 Offset = GameClient()->m_MusicPlayer.GetHudPushOffsetForRect(Rect, HudWidth, HudHeight, 2.0f);
+		Rect.x += Offset.x;
+		Rect.y += Offset.y;
+	}
 	return Rect;
 }
 


### PR DESCRIPTION
## Что изменено

- HUD-элементы освобождают место для раскрытого музыкального плеера с анимацией, не меняя сохранённую раскладку.
- Индикатор микрофона стал вдвое чувствительнее и обновляется плавно на каждом кадре.
- Устранены предупреждения CMake и компилятора.

## Проверка

- `cmake --build build --target DDNet -j4`
- `ninja -C build DDNet -n`
- `git diff --check`
- Сборка с `VULKAN=ON`