### PR TITLE
Add Legit Network as a points provider in scoreboard

### DIFF
--- a/src/engine/shared/config_variables_bestclient.h
+++ b/src/engine/shared/config_variables_bestclient.h
@@ -62,7 +62,7 @@ MACRO_CONFIG_COL(BcNameplateGradientColor4, bc_nameplate_gradient_color4, 0xFFFF
 MACRO_CONFIG_INT(BcNameplateGradientSkin, bc_nameplate_gradient_skin, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Apply gradient colors to player skin body and feet")
 MACRO_CONFIG_INT(BcNameplateGradientEverything, bc_nameplate_gradient_everything, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Apply gradient to all rendered text")
 MACRO_CONFIG_INT(BcNameplateGradientAnimateSpeed, bc_nameplate_gradient_animate_speed, 35, 1, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Speed of the animated gradient sweep, in percent")
-MACRO_CONFIG_INT(BcShowPointsInTab, bc_show_points_in_tab, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show player points in the scoreboard on DDNet and EGO servers")
+MACRO_CONFIG_INT(BcShowPointsInTab, bc_show_points_in_tab, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show player points in the scoreboard on DDNet, EGO and Legit Network servers")
 MACRO_CONFIG_INT(BcShowhudDummyCoordIndicator, bc_showhud_dummy_coord_indicator, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show player-below indicator when aligned above another player")
 MACRO_CONFIG_INT(BcShowCorrectCheckpoint, bc_show_correct_checkpoint, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show current tele checkpoint in movement information")
 

--- a/src/game/client/components/bestclient/show_points.cpp
+++ b/src/game/client/components/bestclient/show_points.cpp
@@ -23,7 +23,7 @@ bool ParsePoints(CShowPoints::EProvider Provider, const json_value *pRoot, int *
 	if(!IsJsonObject(pRoot) || !pPoints)
 		return false;
 
-	if(Provider == CShowPoints::EProvider::Ego)
+	if(Provider == CShowPoints::EProvider::Ego || Provider == CShowPoints::EProvider::Legit)
 	{
 		const json_value *pPointsVal = json_object_get(pRoot, "points");
 		if(pPointsVal == &json_value_none)
@@ -69,7 +69,11 @@ bool CShowPoints::Enabled() const
 
 int CShowPoints::ProviderIndex(EProvider Provider)
 {
-	return Provider == EProvider::Ego ? 1 : 0;
+	if(Provider == EProvider::Ego)
+		return 1;
+	if(Provider == EProvider::Legit)
+		return 2;
+	return 0;
 }
 
 const char *CShowPoints::CurrentCommunityId() const
@@ -125,6 +129,11 @@ CShowPoints::EProvider CShowPoints::CurrentProvider() const
 		str_find_nocase(ServerInfo.m_aName, "eternal gores"))
 	{
 		return EProvider::Ego;
+	}
+
+	if(str_find_nocase(ServerInfo.m_aName, "Legit Network"))
+	{
+		return EProvider::Legit;
 	}
 
 	return EProvider::None;
@@ -254,6 +263,17 @@ void CShowPoints::StartRequest(const std::string &Name, EProvider Provider)
 		char aEscapedLower[256];
 		EscapeUrl(aEscapedLower, sizeof(aEscapedLower), aLower);
 		str_format(aUrl, sizeof(aUrl), "https://eternal-gores.com/profile/%s.json", aEscapedLower);
+	}
+	else if(Provider == EProvider::Legit)
+	{
+		CServerInfo ServerInfo;
+		mem_zero(&ServerInfo, sizeof(ServerInfo));
+		Client()->GetServerInfo(&ServerInfo);
+		const bool IsDDraceMode = str_find_nocase(ServerInfo.m_aGameType, "DDraceNetwork") != nullptr;
+
+		char aEscaped[256];
+		EscapeUrl(aEscaped, sizeof(aEscaped), Name.c_str());
+		str_format(aUrl, sizeof(aUrl), "https://legit.tw/api_points.php?name=%s&mode=%s", aEscaped, IsDDraceMode ? "ddrace" : "gores");
 	}
 	else
 	{

--- a/src/game/client/components/bestclient/show_points.h
+++ b/src/game/client/components/bestclient/show_points.h
@@ -20,6 +20,7 @@ public:
 		None = 0,
 		Ddnet,
 		Ego,
+		Legit,
 	};
 
 	int Sizeof() const override { return sizeof(*this); }
@@ -38,7 +39,7 @@ public:
 private:
 	enum
 	{
-		PROVIDER_COUNT = 2, // Ddnet, Ego
+		PROVIDER_COUNT = 3, // Ddnet, Ego, Legit
 		MAX_CONCURRENT = 3,
 		MAX_QUEUE = 64,
 		SUCCESS_TTL_MS = 10 * 60 * 1000,


### PR DESCRIPTION
Detects Legit Network servers by name (same approach as the existing Ego/eternal-gores provider) and fetches player points from legit.tw's own points API, split by game mode (gores/ddrace) based on the server's reported game type.
